### PR TITLE
Feat: alternative expect file flag

### DIFF
--- a/expect/expect.example.json
+++ b/expect/expect.example.json
@@ -1,0 +1,8 @@
+[
+  {
+    "input": "expected output"
+  },
+  {
+    "another input": "another expect output"
+  }
+]

--- a/src/hackacrow.cr
+++ b/src/hackacrow.cr
@@ -15,7 +15,6 @@ module Hackacrow
     puts "Options:"
     puts "  -h, --help        Display this help menu"
     puts "  -c, --check       Check the output of a command"
-    puts "  -e, --expect FILE Specifies the JSON expect file"
     puts "  -i, --input FILE  Specifies the JSON input file"
     puts "  -o, --output FILE Specifies the JSON output file"
   end

--- a/src/hackacrow.cr
+++ b/src/hackacrow.cr
@@ -15,6 +15,7 @@ module Hackacrow
     puts "Options:"
     puts "  -h, --help        Display this help menu"
     puts "  -c, --check       Check the output of a command"
+    puts "  -e, --expect FILE Specifies the JSON expect file"
     puts "  -i, --input FILE  Specifies the JSON input file"
     puts "  -o, --output FILE Specifies the JSON output file"
   end

--- a/src/run.cr
+++ b/src/run.cr
@@ -14,7 +14,7 @@ module Run
     if ARGV.includes?("-i") || ARGV.includes?("--input")
       i_index = ARGV.index("-i") || ARGV.index("--input")
       if i_index && i_index < ARGV.size - 1
-        input_json_file = File.read(ARGV[i_index + 1])
+        expect_json_file = File.read(ARGV[i_index + 1])
       else
         puts "Argument missing. Usage: hackacrow -i INPUT_FILE"
       end

--- a/src/run.cr
+++ b/src/run.cr
@@ -11,12 +11,12 @@ module Run
   def self.load_expect_data
     expect_json_file = File.read(DEFAULT_EXPECT_JSON_PATH)
 
-    if ARGV.includes?("-e") || ARGV.includes?("--expect")
-      e_index = ARGV.index("-e") || ARGV.index("--expect")
-      if e_index && e_index < ARGV.size - 1
-        expect_json_file = File.read(ARGV[e_index + 1])
+    if ARGV.includes?("-i") || ARGV.includes?("--input")
+      i_index = ARGV.index("-i") || ARGV.index("--input")
+      if i_index && i_index < ARGV.size - 1
+        input_json_file = File.read(ARGV[i_index + 1])
       else
-        puts "Argument missing. Usage: hackacrow -e EXPECT_FILE"
+        puts "Argument missing. Usage: hackacrow -i INPUT_FILE"
       end
     end
 

--- a/src/run.cr
+++ b/src/run.cr
@@ -9,7 +9,18 @@ module Run
   end
 
   def self.load_expect_data
-    JSON.parse(File.read(DEFAULT_EXPECT_JSON_PATH))
+    expect_json_file = File.read(DEFAULT_EXPECT_JSON_PATH)
+
+    if ARGV.includes?("-e") || ARGV.includes?("--expect")
+      e_index = ARGV.index("-e") || ARGV.index("--expect")
+      if e_index && e_index < ARGV.size - 1
+        expect_json_file = File.read(ARGV[e_index + 1])
+      else
+        puts "Argument missing. Usage: hackacrow -e EXPECT_FILE"
+      end
+    end
+
+    JSON.parse(expect_json_file)
   end
 
   def self.run_test(exercise_index : Int, file_name : String)


### PR DESCRIPTION
## What am I changing?

Based on #3, I added a `-e` flag, which sets a expectation file alternative to the default at expect/expect.json.
Also, based on https://github.com/lanjoni/hackacrow/issues/3#issuecomment-1743313712, I also added a simple template (example) file.

The `-e` flag should be up to debate. If you think there's a better naming for it, let me know.

## Screenshots

![image](https://github.com/lanjoni/hackacrow/assets/41875891/756e5c23-6ec8-41c0-b8b9-81d8bd0f152e)
