### PR TITLE
feat: add support for args on the test runner

### DIFF
--- a/src/hackacrow.cr
+++ b/src/hackacrow.cr
@@ -15,6 +15,7 @@ module Hackacrow
     puts "Options:"
     puts "  -h, --help        Display this help menu"
     puts "  -c, --check       Check the output of a command"
+    puts "  -a, --argument    Instead of using stdin to test, use args"
     puts "  -i, --input FILE  Specifies the JSON input file"
     puts "  -o, --output FILE Specifies the JSON output file"
   end
@@ -25,12 +26,13 @@ module Hackacrow
       display_help
     elsif ARGV.includes?("-c") || ARGV.includes?("--check")
       c_index = ARGV.index("-c") || ARGV.index("--check")
+      a_index = ARGV.index("-a") || ARGV.index("--argument")
 
       if c_index && c_index < ARGV.size - 1
         exercise_index = ARGV[c_index + 1].to_i
         file_name = ARGV.last
 
-        Run.run_test(exercise_index, file_name)
+        Run.run_test(exercise_index, file_name, a_index == nil)
       else
         puts "Argument missing. Usage: hackacrow -c EXERCISE_INDEX FILE_NAME"
       end

--- a/src/run.cr
+++ b/src/run.cr
@@ -23,7 +23,7 @@ module Run
     JSON.parse(expect_json_file)
   end
 
-  def self.run_test(exercise_index : Int, file_name : String)
+  def self.run_test(exercise_index : Int, file_name : String, run_with_stdin = true)
     lang_data = load_lang_data
     expect_data = load_expect_data
 
@@ -35,7 +35,12 @@ module Run
         command = "#{lang_data[file_extension]} #{file_name}"
 
         exercise.as_h.each do |key, value|
-          command_output = `echo #{key} | #{command}`.strip
+          if run_with_stdin
+            command_output = `echo #{key} | #{command}`.strip
+          else
+            command_output = `#{command} #{key}`.strip
+          end
+
           output_lines = command_output.split("\n")
           last_line = output_lines.last
           if last_line == value


### PR DESCRIPTION
The `-a` flag it's a boolean one to switch between running the tests with STDIN or with plain arguments, the command should be:

to run with stdin:

```sh
hackacrow -c 2 <path>
```

to run with arguments:

```sh
hackacrow -c 2 -a <path>
```